### PR TITLE
Add improved unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
             <artifactId>javafx-fxml</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/test/java/net/barbux/creatures2d/CreatureTest.java
+++ b/src/test/java/net/barbux/creatures2d/CreatureTest.java
@@ -1,0 +1,100 @@
+package net.barbux.creatures2d;
+
+import net.barbux.creatures2d.Geometry.Vector;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+public class CreatureTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void addInputNotNullOutputTrue() {
+    final Creature creature = new Creature();
+    final Creature.NodeList creatureNodeList = creature.new NodeList();
+    final Creature.Node node = new Creature.Node(2.0, 2.0);
+    Assert.assertTrue(creatureNodeList.add(node));
+  }
+
+  @Test
+  public void cloneOutputNotNull6() {
+    final Creature creature = new Creature();
+    final Creature actual = creature.clone();
+    Assert.assertNotNull(actual);
+    final ArrayList<Creature.Bone> arrayList = new ArrayList<Creature.Bone>();
+    Assert.assertEquals(arrayList, actual.allBones);
+    Assert.assertNotNull(actual.allNodes);
+    Assert.assertNull(actual.physics);
+    Assert.assertEquals(0.0, actual.maxReached, 0.0);
+    final ArrayList<Creature.Muscle> arrayList1 = new ArrayList<Creature.Muscle>();
+    Assert.assertEquals(arrayList1, actual.allMuscles);
+    Assert.assertEquals(0, actual.creatureId);
+  }
+
+  @Test
+  public void constructorOutputNotNull() {
+    final Creature actual = new Creature();
+    Assert.assertNotNull(actual);
+    final ArrayList<Creature.Bone> arrayList = new ArrayList<Creature.Bone>();
+    Assert.assertEquals(arrayList, actual.allBones);
+    Assert.assertNotNull(actual.allNodes);
+    Assert.assertNull(actual.physics);
+    Assert.assertEquals(0.0, actual.maxReached, 0.0);
+    final ArrayList<Creature.Muscle> arrayList1 = new ArrayList<Creature.Muscle>();
+    Assert.assertEquals(arrayList1, actual.allMuscles);
+    Assert.assertEquals(0, actual.creatureId);
+  }
+
+  @Test
+  public void getCenterOutputNotNull() {
+    final Creature creature = new Creature();
+    final Vector actual = creature.getCenter();
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(0x1.fffffffffffffp+1022 /* 8.98847e+307 */, actual.y, 0.0);
+    Assert.assertEquals(0x1.fffffffffffffp+1022 /* 8.98847e+307 */, actual.x, 0.0);
+  }
+
+  @Test
+  public void getFitnessOutputZero() {
+    final Creature creature = new Creature();
+    Assert.assertEquals(0.0, creature.getFitness(), 0.0);
+  }
+
+  @Test
+  public void getInputPositiveOutputIndexOutOfBoundsException() {
+    final Creature creature = new Creature();
+    final Creature.NodeList creatureNodeList = creature.new NodeList();
+    thrown.expect(IndexOutOfBoundsException.class);
+    creatureNodeList.get(3);
+  }
+
+  @Test
+  public void removeInputPositiveOutputIndexOutOfBoundsException() {
+    final Creature creature = new Creature();
+    final Creature.NodeList creatureNodeList = creature.new NodeList();
+    thrown.expect(IndexOutOfBoundsException.class);
+    creatureNodeList.remove(2);
+  }
+
+  @Test
+  public void sizeOutputZero() {
+    final Creature creature = new Creature();
+    final Creature.NodeList creatureNodeList = creature.new NodeList();
+    Assert.assertEquals(0, creatureNodeList.size());
+  }
+
+  @Test
+  public void setExpectedLengthInputPositiveOutputVoid() {
+    final Creature.Node creature$Node = new Creature.Node(0.5, 0.5);
+    final Creature.Node creature$Node1 = new Creature.Node(0.5, 0.5);
+    final Creature.Muscle thisObj = new Creature.Muscle(creature$Node, creature$Node1, 0.5, 0.5, 0.5);
+    final double arg0 = 0.5;
+    thisObj.setExpectedLength(arg0);
+    Assert.assertEquals(-0x1.1a62633145c07p-55 /* -3.06162e-17 */, thisObj.expectedLength, 0.0);
+  }
+}

--- a/src/test/java/net/barbux/creatures2d/GeometryTest.java
+++ b/src/test/java/net/barbux/creatures2d/GeometryTest.java
@@ -1,0 +1,144 @@
+package net.barbux.creatures2d;
+
+import net.barbux.creatures2d.Geometry.Vector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javafx.geometry.Point2D;
+
+public class GeometryTest {
+
+  @Test
+  public void clipEpsilonOutputVoid() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Geometry.Vector geometryVector = new Geometry.Vector(point2D);
+    geometryVector.clipEpsilon();
+  }
+
+  @Test
+  public void cloneOutputNotNull() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector geometryVector = new Vector(point2D);
+    final Vector actual = geometryVector.clone();
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(2.0, actual.y, 0.0);
+    Assert.assertEquals(2.0, actual.x, 0.0);
+  }
+
+  @Test
+  public void constructorInputPositivePositiveOutputNotNull() {
+    final Vector actual = new Vector(2.0, 2.0);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(2.0, actual.y, 0.0);
+    Assert.assertEquals(2.0, actual.x, 0.0);
+  }
+
+  @Test
+  public void diffVectorInputNotNullNotNullOutputNotNull() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector p1 = new Vector(point2D);
+    final Point2D point2D1 = new Point2D(2.0, 2.0);
+    final Vector p2 = new Vector(point2D1);
+    final Vector actual = Geometry.diffVector(p1, p2);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(0.0, actual.y, 0.0);
+    Assert.assertEquals(0.0, actual.x, 0.0);
+  }
+
+  @Test
+  public void constructorInputNotNullOutputNotNull() {
+    final Point2D point = new Point2D(2.0, 2.0);
+    final Vector actual = new Vector(point);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(2.0, actual.y, 0.0);
+    Assert.assertEquals(2.0, actual.x, 0.0);
+  }
+
+  @Test
+  public void distance2InputNotNullNotNullOutputZero() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector p1 = new Vector(point2D);
+    final Point2D point2D1 = new Point2D(2.0, 2.0);
+    final Vector p2 = new Vector(point2D1);
+    Assert.assertEquals(0.0, Geometry.distance2(p1, p2), 0.0);
+  }
+
+  @Test
+  public void minusEqualInputNotNullPositiveOutputVoid() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector geometryVector = new Vector(point2D);
+    final Point2D point2D1 = new Point2D(2.0, 2.0);
+    final Vector other = new Vector(point2D1);
+    geometryVector.minusEqual(other, 2.0);
+    Assert.assertEquals(-2.0, geometryVector.y, 0.0);
+    Assert.assertEquals(-2.0, geometryVector.x, 0.0);
+  }
+
+  @Test
+  public void plusEqualInputNotNullPositiveOutputVoid() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector geometryVector = new Vector(point2D);
+    final Point2D point2D1 = new Point2D(2.0, 2.0);
+    final Vector other = new Vector(point2D1);
+    geometryVector.plusEqual(other, 2.0);
+    Assert.assertEquals(6.0, geometryVector.y, 0.0);
+    Assert.assertEquals(6.0, geometryVector.x, 0.0);
+  }
+
+  @Test
+  public void scaleInputPositiveOutputVoid() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector geometryVector = new Vector(point2D);
+    geometryVector.scale(2.0);
+    Assert.assertEquals(4.0, geometryVector.y, 0.0);
+    Assert.assertEquals(4.0, geometryVector.x, 0.0);
+  }
+
+  @Test
+  public void zeroOutputVoid() {
+    final Point2D point2D = new Point2D(2.0, 2.0);
+    final Vector geometryVector = new Vector(point2D);
+    geometryVector.zero();
+    Assert.assertEquals(0.0, geometryVector.y, 0.0);
+    Assert.assertEquals(0.0, geometryVector.x, 0.0);
+  }
+
+  @Test
+  public void constructorInputNegativeNegativeOutputNotNull() {
+    final double arg0 = -1e-06;
+    final double arg1 = -1e-06;
+    final Vector actual = new Vector(arg0, arg1);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(-1e-06, actual.x, 0.0);
+    Assert.assertEquals(-1e-06, actual.y, 0.0);
+  }
+
+  @Test
+  public void minusEqualInputNotNullNegativeOutputVoid() {
+    final Vector thisObj = new Vector(-1e-06, -1e-06);
+    final Vector arg0 = new Vector(-1e-06, -1e-06);
+    final double arg1 = -1e-06;
+    thisObj.minusEqual(arg0, arg1);
+    Assert.assertEquals(-0x1.0c6f8ba2f85ap-20 /* -1e-06 */, thisObj.x, 0.0);
+    Assert.assertEquals(-0x1.0c6f8ba2f85ap-20 /* -1e-06 */, thisObj.y, 0.0);
+  }
+
+  @Test
+  public void plusEqualInputNotNullNegativeOutputVoid() {
+    final Vector thisObj = new Vector(-1e-06, -1e-06);
+    final Vector arg0 = new Vector(-1e-06, -1e-06);
+    final double arg1 = -1e-06;
+    thisObj.plusEqual(arg0, arg1);
+    Assert.assertEquals(-9.99999e-07, thisObj.x, 0.0);
+    Assert.assertEquals(-9.99999e-07, thisObj.y, 0.0);
+  }
+
+  @Test
+  public void scaleInputNegativeOutputVoid() {
+    final Vector thisObj = new Vector(-1e-06, -1e-06);
+    final double arg0 = -1e-06;
+    thisObj.scale(arg0);
+    Assert.assertEquals(1e-12, thisObj.x, 0.0);
+    Assert.assertEquals(1e-12, thisObj.y, 0.0);
+  }
+}

--- a/src/test/java/net/barbux/creatures2d/PhysicsWithBoneAsSpringTest.java
+++ b/src/test/java/net/barbux/creatures2d/PhysicsWithBoneAsSpringTest.java
@@ -1,0 +1,39 @@
+package net.barbux.creatures2d;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class PhysicsWithBoneAsSpringTest {
+
+  @Test
+  public void constructorOutputNotNull() {
+    final PhysicsWithBoneAsSpring actual = new PhysicsWithBoneAsSpring();
+    Assert.assertNotNull(actual);
+    Assert.assertNull(actual.creature);
+  }
+
+  @Test
+  public void initializeInputNotNullOutputVoid() {
+    final PhysicsWithBoneAsSpring physicsWithBoneAsSpring = new PhysicsWithBoneAsSpring();
+    final Creature creature = new Creature();
+    physicsWithBoneAsSpring.initialize(creature);
+    Assert.assertNotNull(physicsWithBoneAsSpring.creature);
+    final ArrayList<Creature.Bone> arrayList = new ArrayList<Creature.Bone>();
+    Assert.assertEquals(arrayList, physicsWithBoneAsSpring.creature.allBones);
+    Assert.assertNotNull(physicsWithBoneAsSpring.creature.allNodes);
+    Assert.assertNull(physicsWithBoneAsSpring.creature.physics);
+    Assert.assertEquals(0.0, physicsWithBoneAsSpring.creature.maxReached, 0.0);
+    final ArrayList<Creature.Muscle> arrayList1 = new ArrayList<Creature.Muscle>();
+    Assert.assertEquals(arrayList1, physicsWithBoneAsSpring.creature.allMuscles);
+    Assert.assertEquals(0, physicsWithBoneAsSpring.creature.creatureId);
+  }
+
+  @Test
+  public void getEnergyOutputPositive() {
+    final Creature.Node creature$Node = new Creature.Node(0x1.00000000001p+1 /* 2.0 */, 0x1.8d9ffede021cdp+7 /* 198.812 */);
+    final PhysicsWithBoneAsSpring.NodeData physicsWithBoneAsSpringNodeData = new PhysicsWithBoneAsSpring.NodeData(creature$Node);
+    Assert.assertEquals(0x1.e7966f403cd4ap+10 /* 1950.35 */, physicsWithBoneAsSpringNodeData.getEnergy(), 0.0);
+  }
+}

--- a/src/test/java/net/barbux/creatures2d/PhysicsWithSolidBonesTest.java
+++ b/src/test/java/net/barbux/creatures2d/PhysicsWithSolidBonesTest.java
@@ -1,0 +1,70 @@
+package net.barbux.creatures2d;
+
+import net.barbux.creatures2d.Creature.Bone;
+import net.barbux.creatures2d.Creature.Node;
+import net.barbux.creatures2d.PhysicsWithSolidBones.Solid;
+import net.barbux.creatures2d.PhysicsWithSolidBones.SolidCandidate;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.BitSet;
+
+public class PhysicsWithSolidBonesTest {
+
+  @Test
+  public void constructorOutputNotNull() {
+    final SolidCandidate actual = new SolidCandidate();
+    Assert.assertNotNull(actual);
+    Assert.assertNull(actual.solid);
+    final BitSet bitSet = new BitSet();
+    Assert.assertEquals(bitSet, actual.nodes);
+  }
+
+  @Test
+  public void hasNodeInputNotNullOutputFalse() {
+    final SolidCandidate physicsWithSolidBonesSolidCandidate = new SolidCandidate();
+    final Node node = new Node(2.0, 2.0);
+    Assert.assertFalse(physicsWithSolidBonesSolidCandidate.hasNode(node));
+  }
+
+  @Test
+  public void isEmptyOutputTrue() {
+    final SolidCandidate physicsWithSolidBonesSolidCandidate = new SolidCandidate();
+    Assert.assertTrue(physicsWithSolidBonesSolidCandidate.isEmpty());
+  }
+
+  @Test
+  public void isSameSolidInputNotNullNotNullOutputFalse() {
+    final SolidCandidate physicsWithSolidBonesSolidCandidate = new SolidCandidate();
+    final SolidCandidate other = new SolidCandidate();
+    final ArrayList<Bone> allBones = new ArrayList<Bone>();
+    Assert.assertFalse(physicsWithSolidBonesSolidCandidate.isSameSolid(other, allBones));
+  }
+
+  @Test
+  public void isSameSolidInputNotNull0OutputFalse() {
+    final SolidCandidate physicsWithSolidBonesSolidCandidate = new SolidCandidate();
+    physicsWithSolidBonesSolidCandidate.solid = null;
+    final BitSet bitSet = new BitSet();
+    bitSet.set(2);
+    physicsWithSolidBonesSolidCandidate.nodes = bitSet;
+    final SolidCandidate other = new SolidCandidate();
+    other.solid = null;
+    final BitSet bitSet1 = new BitSet();
+    bitSet1.set(2);
+    other.nodes = bitSet1;
+    final ArrayList<Bone> allBones = new ArrayList<Bone>();
+    Assert.assertFalse(physicsWithSolidBonesSolidCandidate.isSameSolid(other, allBones));
+  }
+
+  @Test
+  public void constructorInputNullOutputNotNull() {
+    final Solid actual = new Solid(null);
+    Assert.assertNotNull(actual);
+    Assert.assertNull(actual.color);
+    final ArrayList<Node> arrayList = new ArrayList<Node>();
+    Assert.assertEquals(arrayList, actual.nodes);
+    final ArrayList<Bone> arrayList1 = new ArrayList<Bone>();
+    Assert.assertEquals(arrayList1, actual.bones);
+  }
+}

--- a/src/test/java/net/barbux/creatures2d/ScrewTheoryTest.java
+++ b/src/test/java/net/barbux/creatures2d/ScrewTheoryTest.java
@@ -1,0 +1,61 @@
+package net.barbux.creatures2d;
+
+import net.barbux.creatures2d.ScrewTheory.Vector3D;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScrewTheoryTest {
+
+  @Test
+  public void constructorInputPositivePositivePositiveOutputNotNull() {
+    final Vector3D actual = new Vector3D(2.0, 2.0, 2.0);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(2.0, actual.z, 0.0);
+    Assert.assertEquals(2.0, actual.x, 0.0);
+    Assert.assertEquals(2.0, actual.y, 0.0);
+  }
+
+  @Test
+  public void productInputNotNullNotNullOutputNotNull() {
+    final ScrewTheory.Point3D screwTheory$Point3D = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    final ScrewTheory.Point3D screwTheory$Point3D1 = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    final Vector3D v1 = new Vector3D(screwTheory$Point3D, screwTheory$Point3D1);
+    final ScrewTheory.Point3D screwTheory$Point3D2 = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    final ScrewTheory.Point3D screwTheory$Point3D3 = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    final Vector3D v2 = new Vector3D(screwTheory$Point3D2, screwTheory$Point3D3);
+    final Vector3D actual = ScrewTheory.product(v1, v2);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(0.0, actual.z, 0.0);
+    Assert.assertEquals(0.0, actual.x, 0.0);
+    Assert.assertEquals(0.0, actual.y, 0.0);
+  }
+
+  @Test
+  public void constructorInputNotNullNotNullOutputNotNull() {
+    final ScrewTheory.Point3D A = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    final ScrewTheory.Point3D B = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    final Vector3D actual = new Vector3D(A, B);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(0.0, actual.z, 0.0);
+    Assert.assertEquals(0.0, actual.x, 0.0);
+    Assert.assertEquals(0.0, actual.y, 0.0);
+  }
+
+  @Test
+  public void constructorInputPositivePositivePositiveOutputNotNull1() {
+    final ScrewTheory.Point3D actual = new ScrewTheory.Point3D(2.0, 2.0, 2.0);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(2.0, actual.z, 0.0);
+    Assert.assertEquals(2.0, actual.x, 0.0);
+    Assert.assertEquals(2.0, actual.y, 0.0);
+  }
+
+  @Test
+  public void constructorOutputNotNull() {
+    final ScrewTheory.Screw actual = new ScrewTheory.Screw();
+    Assert.assertNotNull(actual);
+    Assert.assertNull(actual.M);
+    Assert.assertNull(actual.point);
+    Assert.assertNull(actual.R);
+  }
+}

--- a/src/test/java/net/barbux/creatures2d/WorldTest.java
+++ b/src/test/java/net/barbux/creatures2d/WorldTest.java
@@ -1,0 +1,60 @@
+package net.barbux.creatures2d;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class WorldTest {
+
+  @Test
+  public void constructorInputNull1OutputNotNull() {
+    final ArrayList<Creature> creatures = new ArrayList<Creature>();
+    creatures.add(null);
+    final World actual = new World(null, creatures);
+    Assert.assertNotNull(actual);
+    final ArrayList<Creature> arrayList = new ArrayList<Creature>();
+    arrayList.add(null);
+    Assert.assertEquals(arrayList, actual.creatures);
+    Assert.assertEquals(0L, actual.lastUpdateNanos);
+    Assert.assertNull(actual.physicsSupplier);
+  }
+
+  @Test
+  public void constructorInputNull3OutputNotNull() {
+    final ArrayList<Creature> creatures = new ArrayList<Creature>();
+    creatures.add(null);
+    creatures.add(null);
+    creatures.add(null);
+    final World actual = new World(null, creatures);
+    Assert.assertNotNull(actual);
+    final ArrayList<Creature> arrayList = new ArrayList<Creature>();
+    arrayList.add(null);
+    arrayList.add(null);
+    arrayList.add(null);
+    Assert.assertEquals(arrayList, actual.creatures);
+    Assert.assertEquals(0L, actual.lastUpdateNanos);
+    Assert.assertNull(actual.physicsSupplier);
+  }
+
+  @Test
+  public void constructorInputNullNotNullOutputNotNull() {
+    final ArrayList<Creature> creatures = new ArrayList<Creature>();
+    final World actual = new World(null, creatures);
+    Assert.assertNotNull(actual);
+    final ArrayList<Creature> arrayList = new ArrayList<Creature>();
+    Assert.assertEquals(arrayList, actual.creatures);
+    Assert.assertEquals(0L, actual.lastUpdateNanos);
+    Assert.assertNull(actual.physicsSupplier);
+  }
+
+  @Test
+  public void constructorInputNullOutputNotNull() {
+    final World actual = new World(null);
+    Assert.assertNotNull(actual);
+    final ArrayList<Creature> arrayList = new ArrayList<Creature>();
+    Assert.assertEquals(arrayList, actual.creatures);
+    Assert.assertEquals(0L, actual.lastUpdateNanos);
+    Assert.assertNull(actual.physicsSupplier);
+  }
+}


### PR DESCRIPTION
Hi, 

Based on your feedback for PR https://github.com/wonsjb/creatures2d/pull/2, we’ve rerun the analysis using different configuration settings for Diffblue Cover

The tests here a subset of the total tests produced for the project.

If we are unable to produce a test for a method by accessing the object and its properties natively via constructors and/or public getters & setters, we fall back to using mocking and reflection in order to reach/access the lines/properties under test.

Unfortunately Diffblue Cover at this present moment in time doesn't fully support parts of the Oracle JDK v8, such as JavaFX, as we primarily support OpenJDK which as of yet does not include an implementation of JavaFX in v8. As a result, this affects the quality of the tests we produce.

Submitted in this PR are the tests that don't use reflection and/or unnecessary mocking, with the assumption that these tests are preferable to use as they are more readable and easier to maintain.

Specifically in relation to your feedback from the previous PR, I have now included tests written for the `Geometry` class, as well as excluded tests for more trivial methods, such as `hashCode`. Also, in order to test the `RandomCreature` constructors correctly with consistent results, mocking is required in order to ensure identical values are assigned to the class.


